### PR TITLE
Allow opening read-only files and files in read-only locations.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2023 dujingning
+Copyright (c) 2025 Drew Naylor
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I had a problem where I was trying to open .desktop files in `/usr/share/applications` and it would silently fail, but eventually I figured out it was trying to open them read-write. Figured that out eventually when I realized it worked with a file on my desktop but not `/usr/share/applications` (took a while to figure out, though). Obviously writing isn't allowed in that folder, so it didn't work. This PR adds an option to pass `false` when creating an `IniManager` so that it will only open it for reading and not for writing. It will default to `true` to maintain the existing functionality and shouldn't break anything. At the bottom where `modify()` calls `parse()`, I assumed it would want to open it for writing again, so I passed `true` there. I tested this by building the example and it seems to work fine.